### PR TITLE
Add a Dockerfile to enable easily building / running in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM ubuntu:22.04 as build-container
+
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    cmake
+    
+WORKDIR /app
+COPY . .
+RUN rm -rf build
+RUN mkdir build
+WORKDIR /app/build
+RUN cmake -DCMAKE_BUILD_TYPE=Release ..
+RUN make -j2
+
+# Run container without build dependencies
+FROM ubuntu:22.04 as run-container
+
+WORKDIR /app
+COPY --from=build-container /app/build/ilash /app/ilash
+CMD "/app/ilash"


### PR DESCRIPTION
My group has been using iLASH inside of Docker to make running it in cloud environments easier.

Add a basic dockerfile that packages iLASH inside of Ubuntu 22.04 Docker container

The runtime image ends up at about 77MB in size, smaller compressed.