### PR TITLE
Performance: Use boost::tokenizer to read lines in filereader, increasing performance

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 project(ilash)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
+set(CMAKE_CXX_STANDARD 14)
 
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,12 @@
 cmake_minimum_required(VERSION 3.5)
 project(ilash)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
 
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
+find_package(Boost REQUIRED)
+include_directories(${Boost_INCLUDE_DIRS})
 
 set(SOURCE_FILES src/main.cpp src/headers/context.h src/context.cpp src/headers/filereader.h src/headers/experiment.h src/headers/corpus.h src/headers/fnv.h src/headers/minhasher.h src/headers/lsh_slave.h src/filereader.cpp src/minhasher.cpp src/experiment.cpp src/corpus.cpp src/lsh_slave.cpp src/headers/writer.h src/writer.cpp)
 add_executable(ilash ${SOURCE_FILES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 project(ilash)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
 
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)

--- a/README.md
+++ b/README.md
@@ -10,8 +10,16 @@ https://doi.org/10.1038/s41467-021-22910-w
 
 ## Compilation and System Requirements
 
-To compile iLASH, CMAKE v3.5 or higher is required.
-First, create a directory to generate the Makefile:
+To compile iLASH, CMAKE v3.5 or higher is required. You will need the Boost libraries headers on your system, as 
+boost::tokenizer is used for reading input. Your distribution's normal boost distribution should work, some examples are below:
+
+Installing boost with homebrew: `brew install boost`
+
+Installing boost from aptitude: `sudo apt install libboost-dev`
+
+Or Boost can be installed [from source](https://www.boost.org/doc/libs/1_79_0/more/getting_started/index.html)
+
+Then, create a directory to generate the Makefile:
 
 `$ mkdir build`
 

--- a/README.md
+++ b/README.md
@@ -25,15 +25,15 @@ Then, create a directory to generate the Makefile:
 
 `$ cd build`
 
- C++ compiler used by CMAKE should support C++ 11 standard (GCC 4.8.1 or later versions). POSIX threads library is recommended for multi-threading features.
+ C++ compiler used by CMAKE should support C++ 14 standard (GCC 5 or later versions). POSIX threads library is recommended for multi-threading features.
 
 iLASH has been tested and successfully compiled using the following compilers:
 
 `Apple LLVM version 10.0.1 (clang-1001.0.46.4)- On macOS (Catalina & Mojave) - MacBook Pro, Mid 2015, 2.5 GHz Quad-Core Intel Core i7 with 16 GB DDR3 Memory`
 
-`GCC 4.8.5 on CentOS 7 - 12 Core Intel Xeon E5-2695 2.4 GHz with 128 GB DDR2 Memory`
+`Apple Clang 13.1.6 - MacOS 12.4 on MacBook Air (M1, 2020)`
 
-`GCC 5.0 on Ubuntu 14.04 - 28 Core Intel Virtual Machine with 256 GB of DDR3 Memory on Google Cloud Platform.`
+`GCC 9.4.0 on Ubuntu 20.04`
 
 Generate the Makefile using the following command.
 

--- a/sample_config
+++ b/sample_config
@@ -17,7 +17,7 @@ shingle_overlap 0
 
 bucket_count 5
 
-max_thread 20
+max_thread 2
 
 match_threshold 0.99
 

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -223,7 +223,6 @@ void Context::prepare_context(RunOptions * runOptions) {
 
     this->thread_count = std::thread::hardware_concurrency();
     cout<<"The number of cores on the host: "<<this->thread_count<<endl;
-    this->thread_count *= 2;
     if(runOptions->max_thread > 0 )
         this->thread_count = runOptions->max_thread;
 

--- a/src/experiment.cpp
+++ b/src/experiment.cpp
@@ -18,7 +18,7 @@ using namespace std;
 //Thread handle function for LSH worker threads in a master-slave model.
 //Instantiates a LSH slave instance and then runs it.
 //All the inputs are the required inputs for LSH threads.
-void lsh_thread(Corpus *corpus, std::mutex * linesLock, shared_ptr<queue<unique_ptr<std::string>>> linesQ, bool *runFlag){
+void lsh_thread(Corpus *corpus, std::mutex * linesLock, shared_ptr<queue<unique_ptr<std::string>>> linesQ, atomic_bool *runFlag){
     LSH_Slave slave(corpus,linesLock,move(linesQ),runFlag);
     slave.run();
 }
@@ -43,13 +43,12 @@ void Experiment::read_bulk(const char *input_addr, const char *output_addr) {
 
     auto linesQ = make_shared<queue<unique_ptr<string>>>(); //Samples will be loaded in the this queue
     auto *linesLock = new mutex; //This lock is in charge of synchronizing the linesQ
-    bool runFlag = true;
+    atomic_bool runFlag(true);
 
     vector<thread> lsh_thread_list;
 
     for(unsigned i = 0; i < this->context.thread_count; i++){
         lsh_thread_list.emplace_back(lsh_thread,&(this->corpus),linesLock,linesQ,&runFlag);
-
     }
     cout<<"Threads started"<<endl;
 

--- a/src/experiment.cpp
+++ b/src/experiment.cpp
@@ -12,6 +12,7 @@
 #include <queue>
 #include <mutex>
 #include <fstream>
+#include <atomic>
 
 using namespace std;
 

--- a/src/experiment.cpp
+++ b/src/experiment.cpp
@@ -18,7 +18,7 @@ using namespace std;
 //Thread handle function for LSH worker threads in a master-slave model.
 //Instantiates a LSH slave instance and then runs it.
 //All the inputs are the required inputs for LSH threads.
-void lsh_thread(Corpus *corpus, std::mutex * linesLock, shared_ptr<queue<unique_ptr<std::string>>> linesQ, atomic_bool *runFlag){
+void lsh_thread(Corpus *corpus, std::mutex * linesLock, shared_ptr<queue<unique_ptr<std::string>>> linesQ, atomic<bool> *runFlag){
     LSH_Slave slave(corpus,linesLock,move(linesQ),runFlag);
     slave.run();
 }
@@ -43,7 +43,7 @@ void Experiment::read_bulk(const char *input_addr, const char *output_addr) {
 
     auto linesQ = make_shared<queue<unique_ptr<string>>>(); //Samples will be loaded in the this queue
     auto *linesLock = new mutex; //This lock is in charge of synchronizing the linesQ
-    atomic_bool runFlag(true);
+    atomic<bool> runFlag(true);
 
     vector<thread> lsh_thread_list;
 

--- a/src/filereader.cpp
+++ b/src/filereader.cpp
@@ -13,15 +13,26 @@
 
 
 using namespace std;
+
+// Safely read the next value from the line iterator
+inline string get_next(boost::tokenizer<>::iterator& it, boost::tokenizer<>::iterator& end) {
+    if (it == end) {
+        throw DimensionException();
+    }
+
+    return *it++;
+}
+
 filereader::filereader(unique_ptr<string> input_string, Context * context) {
     // Instead of an istringstream, read the const string into a boost::tokenizer
     boost::tokenizer<> tok(*input_string);
     boost::tokenizer<>::iterator iter = tok.begin();
+    auto end = tok.end();
 
     this->context = context;
 
     for(unsigned i= 0 ; i<meta_size; i++){
-        this->meta[i] = *iter++;
+        this->meta[i] = get_next(iter, end);
     }
     this->ind = 0;
     this->shingle_ind = 0;
@@ -36,15 +47,15 @@ filereader::filereader(unique_ptr<string> input_string, Context * context) {
     this->dna_hash[1] = new uint32_t[this->context->shingle_map.size()];
 
     this->hash_buffer = new uint32_t[2];
-    dnabit temp_bits;
 
     for(unsigned i = 0 ; i < this->context->map_data.size(); i++){
-        this->bits[0][i] = iter++->front();
-        this->bits[1][i] = iter++->front();
-//        if(iter == tok.end()) {
-//            //throw exception
-//            throw DimensionException();
-//        }
+        this->bits[0][i] = get_next(iter, end).front();
+        this->bits[1][i] = get_next(iter, end).front();
+    }
+
+    if(iter != tok.end()) {
+        //throw exception
+        throw DimensionException();
     }
 }
 

--- a/src/filereader.cpp
+++ b/src/filereader.cpp
@@ -21,8 +21,7 @@ filereader::filereader(unique_ptr<string> input_string, Context * context) {
     this->context = context;
 
     for(unsigned i= 0 ; i<meta_size; i++){
-        this->meta[i] = *iter;
-        ++iter;
+        this->meta[i] = *iter++;
     }
     this->ind = 0;
     this->shingle_ind = 0;
@@ -40,8 +39,8 @@ filereader::filereader(unique_ptr<string> input_string, Context * context) {
     dnabit temp_bits;
 
     for(unsigned i = 0 ; i < this->context->map_data.size(); i++){
-        this->bits[0][i] = iter->front(); ++iter; // Validate that -> front will get the first char of a string
-        this->bits[1][i] = iter->front(); ++iter;
+        this->bits[0][i] = iter++->front();
+        this->bits[1][i] = iter++->front();
 //        if(iter == tok.end()) {
 //            //throw exception
 //            throw DimensionException();

--- a/src/filereader.cpp
+++ b/src/filereader.cpp
@@ -9,15 +9,20 @@
 #include "headers/fnv.h"
 #include "headers/context.h"
 #include <iostream>
+#include <boost/tokenizer.hpp>
 
 
 using namespace std;
-filereader::filereader(std::string * input_string,Context * context):iss(*input_string) {
-    this->source = input_string;
+filereader::filereader(unique_ptr<string> input_string, Context * context) {
+    // Instead of an istringstream, read the const string into a boost::tokenizer
+    boost::tokenizer<> tok(*input_string);
+    boost::tokenizer<>::iterator iter = tok.begin();
+
     this->context = context;
 
     for(unsigned i= 0 ; i<meta_size; i++){
-        this->iss>>this->meta[i];
+        this->meta[i] = *iter;
+        ++iter;
     }
     this->ind = 0;
     this->shingle_ind = 0;
@@ -35,19 +40,13 @@ filereader::filereader(std::string * input_string,Context * context):iss(*input_
     dnabit temp_bits;
 
     for(unsigned i = 0 ; i < this->context->map_data.size(); i++){
-        this->iss>>this->bits[0][i];
-        this->iss>>this->bits[1][i];
-        if(this->iss.tellg()==-1){
-            //throw exception
-            throw DimensionException();
-        }
-        
+        this->bits[0][i] = iter->front(); ++iter; // Validate that -> front will get the first char of a string
+        this->bits[1][i] = iter->front(); ++iter;
+//        if(iter == tok.end()) {
+//            //throw exception
+//            throw DimensionException();
+//        }
     }
-    this->iss>>temp_bits;
-    if(this->iss.tellg() != -1){
-        throw DimensionException();
-    }
-    delete input_string;
 }
 
 

--- a/src/headers/filereader.h
+++ b/src/headers/filereader.h
@@ -21,9 +21,6 @@
 const unsigned meta_size = 6;
 
 class filereader {
-    std::string * source;
-    std::istringstream iss;
-
     unsigned long ind;
     unsigned long last;
     unsigned long head;
@@ -40,7 +37,7 @@ public:
     uint32_t ** dna_hash;
     unsigned shingle_ind;
 
-    filereader(std::string *, Context *);
+    filereader(std::unique_ptr<std::string> input_string, Context *context);
     uint32_t* getNextHashed();
     ~filereader();
     bool hasNext();

--- a/src/headers/lsh_slave.h
+++ b/src/headers/lsh_slave.h
@@ -24,9 +24,9 @@ class LSH_Slave{
     Corpus * corpus;
     std::mutex *linesLock;
     std::shared_ptr<std::queue<std::unique_ptr< std::string>>> linesQ;
-    std::atomic_bool * runFlag; //This flag tells the program when to stop listening.
+    std::atomic<bool> * runFlag; //This flag tells the program when to stop listening.
 public:
-    LSH_Slave(Corpus *corpus, std::mutex *linesLock, std::shared_ptr<std::queue<std::unique_ptr<std::string>>>, std::atomic_bool *);
+    LSH_Slave(Corpus *corpus, std::mutex *linesLock, std::shared_ptr<std::queue<std::unique_ptr<std::string>>>, std::atomic<bool> *);
     void run(); //When the master thread is ready, it will call this function. This action initiates the process of readding from the queue and parsing it.
     inline void corpus_generator( uint32_t ** , std::unordered_map<uint32_t,unsigned short> *, unsigned ,uint32_t *);
     inline void aggregator(std::unordered_map<uint32_t,unsigned short> *, unsigned ,uint32_t *);

--- a/src/headers/lsh_slave.h
+++ b/src/headers/lsh_slave.h
@@ -23,10 +23,10 @@
 class LSH_Slave{
     Corpus * corpus;
     std::mutex *linesLock;
-    std::queue<std::string*> *linesQ;
+    std::shared_ptr<std::queue<std::unique_ptr< std::string>>> linesQ;
     bool * runFlag; //This flag tells the program when to stop listening. 
 public:
-    LSH_Slave(Corpus *,std::mutex *,std::queue<std::string*> * ,bool *);
+    LSH_Slave(Corpus *corpus, std::mutex *linesLock, std::shared_ptr<std::queue<std::unique_ptr<std::string>>>, bool *);
     void run(); //When the master thread is ready, it will call this function. This action initiates the process of readding from the queue and parsing it.
     inline void corpus_generator( uint32_t ** , std::unordered_map<uint32_t,unsigned short> *, unsigned ,uint32_t *);
     inline void aggregator(std::unordered_map<uint32_t,unsigned short> *, unsigned ,uint32_t *);

--- a/src/headers/lsh_slave.h
+++ b/src/headers/lsh_slave.h
@@ -24,9 +24,9 @@ class LSH_Slave{
     Corpus * corpus;
     std::mutex *linesLock;
     std::shared_ptr<std::queue<std::unique_ptr< std::string>>> linesQ;
-    bool * runFlag; //This flag tells the program when to stop listening. 
+    std::atomic_bool * runFlag; //This flag tells the program when to stop listening.
 public:
-    LSH_Slave(Corpus *corpus, std::mutex *linesLock, std::shared_ptr<std::queue<std::unique_ptr<std::string>>>, bool *);
+    LSH_Slave(Corpus *corpus, std::mutex *linesLock, std::shared_ptr<std::queue<std::unique_ptr<std::string>>>, std::atomic_bool *);
     void run(); //When the master thread is ready, it will call this function. This action initiates the process of readding from the queue and parsing it.
     inline void corpus_generator( uint32_t ** , std::unordered_map<uint32_t,unsigned short> *, unsigned ,uint32_t *);
     inline void aggregator(std::unordered_map<uint32_t,unsigned short> *, unsigned ,uint32_t *);

--- a/src/lsh_slave.cpp
+++ b/src/lsh_slave.cpp
@@ -2,6 +2,7 @@
 // Created by Ruhollah Shemirani on 3/29/17.
 //
 
+#include <atomic>
 #include <vector>
 #include "headers/filereader.h"
 #include "headers/minhasher.h"

--- a/src/lsh_slave.cpp
+++ b/src/lsh_slave.cpp
@@ -18,7 +18,7 @@
 
 using namespace std;
 
-LSH_Slave::LSH_Slave(Corpus * corpus, std::mutex *linesLock, shared_ptr<queue<unique_ptr<string>>> linesQ, atomic_bool *runFlag) {
+LSH_Slave::LSH_Slave(Corpus * corpus, std::mutex *linesLock, shared_ptr<queue<unique_ptr<string>>> linesQ, atomic<bool> *runFlag) {
     this->corpus = corpus;
     this->linesLock = linesLock;
     this->linesQ = move(linesQ);

--- a/src/lsh_slave.cpp
+++ b/src/lsh_slave.cpp
@@ -18,10 +18,10 @@
 
 using namespace std;
 
-LSH_Slave::LSH_Slave(Corpus * corpus, std::mutex *linesLock, shared_ptr<queue<unique_ptr<string>>> linesQ, bool *runFlag) {
+LSH_Slave::LSH_Slave(Corpus * corpus, std::mutex *linesLock, shared_ptr<queue<unique_ptr<string>>> linesQ, atomic_bool *runFlag) {
     this->corpus = corpus;
     this->linesLock = linesLock;
-    this->linesQ = linesQ;
+    this->linesQ = move(linesQ);
     this->runFlag = runFlag;
 }
 


### PR DESCRIPTION
While looking at where things would have to change to have iLASH read in VCF files as well, I noticed that the parsing was being done with `operator>>` on an `istringstream`. This is one of the slowest ways to read in text, so I thought I'd see if performance could be improved by reading the string without copying. 

This PR increases performance by about 20x on a medium-sized (2.78GB .ped file) dataset on my M1 Macbook Air. This potentially makes the threading less necessary in general.

There's three major changes in this PR, any of which I could remove if you don't want them:

1. Introduce the [Boost tokenizer](https://theboostcpplibraries.com/boost.tokenizer) as a dependency: There are several ways to do zero-copy string splitting, but this is one of the most comfortable. It's header only, so no libraries are necessary at runtime. If you don't want to introduce boost, the core performance improvement could be done without this.
2. Move some of the pointers to smart pointers: Less potential for human error, better ergonomics.
3. Make runFlag atomic: A change to a non-atomic boolean without any other synchronization is _never_ guaranteed to be seen by other threads, meaning that the worker threads may never see runFlag set to false unless it's made atomic or protected by mutexes. This is particularly necessary on non-x86 computers like the new Macs, as x86 has a stricter memory model than ARM.

Let me know if you like any of these changes, or would like me to reverse any parts of them.