### PR TITLE
Fix the build on Ubuntu 22.04: missing #include

### DIFF
--- a/src/headers/lsh_slave.h
+++ b/src/headers/lsh_slave.h
@@ -17,7 +17,7 @@
 #include <map>
 #include <fstream>
 #include <unordered_map>
-
+#include <memory>
 
 
 class LSH_Slave{


### PR DESCRIPTION
Add #include <memory>, which defines the shared_ptr type.

This fixes:
https://github.com/roohy/iLASH/issues/7

There's more include cleanup and fixup that could be done, but this builds and works on Ubuntu 22.04 at least.